### PR TITLE
Add in option to only show audit results for directories.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "dfs_usage_audit"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfs_usage_audit"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ target
 ## Usage
 
 ```bash
-target/aarch64-apple-darwin/release/dfs_usage_audit --help
 Usage: dfs_usage_audit [OPTIONS] --path <PATH>
 
 Options:
-  -o, --out-file <OUT_FILE>  [default: DFS_audit.csv]
-  -p, --path <PATH>
-  -t, --threads <THREADS>    [default: 50]
-  -d, --days <DAYS>          [default: 1095]
+  -o, --out-file <OUT_FILE>  Relative path to export audit results. [default: DFS_audit.csv]
+  -p, --path <PATH>          The path to the directory/DFS space you wish to audit.
+  -d, --directories          Whether to include only directories. Does not take a value
+  -t, --threads <THREADS>    The amount of threads to use for performance.Higher is faster, but can be less accurate. I've found 50 to be the best tradeoff. Never inaccurate. [default: 50]
+  -d, --days <DAYS>          Cut-off, in days, to include. e.g. 365 to show files not accessed in the last year. [default: 1095]
   -h, --help                 Print help
   -V, --version              Print version
 ```


### PR DESCRIPTION
This limits the results to a more management amount, and gives a good estimate of the files inside, which should always be the same or longer since access.
Also added more descriptive help messages for each cli argument.